### PR TITLE
Add support for defining persistent state in a script

### DIFF
--- a/sha1.lua
+++ b/sha1.lua
@@ -85,7 +85,7 @@ local function sha1_feed_64(H, str, offs, size)
 	H[1], H[2], H[3], H[4], H[5] = h1, h2, h3, h4, h5
 end
 
-local function sha1(message): string
+local function sha1(message: string): string
 	-- Create an instance (private objects for current calculation)
 	local H, length, tail = table.pack(table.unpack(md5_sha1_H)), 0, ""
 


### PR DESCRIPTION
This fixes a bug where state defined inside of a service script wouldn't sync correctly.
This adds a `inlineState` function to make using inline state simple.
Here's an example of inline state in action:
```lua
local ReplicatedStorage = game:GetService("ReplicatedStorage")

local fluf = require(ReplicatedStorage.Packages.fluf)

local firstEnabled = fluf.inlineState(DateTime.now())
local count, setCount = fluf.inlineState(0)

print(
    "Timer started! This was first enabled at",
    firstEnabled:FormatLocalTime("LTS", "en-us")
)

fluf.onDisabled(script, function()
    print("Timer was stopped.")
end)

while true do
    task.wait(1)
    count = setCount(count + 1)
    print("Timer has been active for " .. count .. " seconds.")
end
```